### PR TITLE
Backport a simplified version of #17130

### DIFF
--- a/pkg/workloadmeta/collectors/internal/ecs/ecs.go
+++ b/pkg/workloadmeta/collectors/internal/ecs/ecs.go
@@ -146,7 +146,7 @@ func (c *collector) parseTasks(ctx context.Context, tasks []v1.Task) []workloadm
 			Containers:  taskContainers,
 		}
 
-		if c.hasResourceTags {
+		if false {
 			rt := c.getResourceTags(ctx, entity)
 			entity.ContainerInstanceTags = rt.containerInstanceTags
 			entity.Tags = rt.tags


### PR DESCRIPTION
The idea of #17130 is to only fetch resource tags for new tasks if we will actually use them. We'd like to backport it, but there are some conflicts in the plumbing changes. Instead, let's just temporarily hardcode the assumption that we don't need the resource tags.